### PR TITLE
Basic python3 compatibility

### DIFF
--- a/IrcamForum/IrcamFindAndDownload.py
+++ b/IrcamForum/IrcamFindAndDownload.py
@@ -445,7 +445,7 @@ class IrcamFindAndDownload(Processor):
             raise ProcessorError('Could not retrieve URL: %s when attempting to get auth cookie' % authURL)
 
         # Check returned content doesn't indicate auth failure
-        re_pattern = re.compile("Incorrect\susername")
+        re_pattern = re.compile(r"Incorrect\susername")
         match = re_pattern.search(content)
         if match:
             os.remove(cookiePath)

--- a/IrcamForum/IrcamFindAndDownload.py
+++ b/IrcamForum/IrcamFindAndDownload.py
@@ -282,7 +282,7 @@ class IrcamFindAndDownload(Processor):
             else:
                 time.sleep(0.1)
 
-            if proc.poll() != None:
+            if proc.poll() is not None:
                 # For small download files curl may exit before all headers
                 # have been parsed, don't immediately exit.
                 maxheaders -= 1

--- a/IrcamForum/IrcamFindAndDownload.py
+++ b/IrcamForum/IrcamFindAndDownload.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for IrcamFindAndDownload class"""
 
+from __future__ import absolute_import
 import os.path
 import re
 import subprocess
@@ -171,7 +172,7 @@ class IrcamFindAndDownload(Processor):
         if not os.path.exists(download_dir):
             try:
                 os.makedirs(download_dir)
-            except OSError, err:
+            except OSError as err:
                 os.remove(cookiePath)
                 raise ProcessorError(
                     "Can't create %s: %s" % (download_dir, err.strerror))
@@ -185,7 +186,7 @@ class IrcamFindAndDownload(Processor):
         # this can cause issues if this item is eventually copied to a Munki repo
         # with the same permissions and the file is inaccessible by (for example)
         # the webserver.
-        os.chmod(pathname_temporary, 0644)
+        os.chmod(pathname_temporary, 0o644)
 
         # construct curl command.
         curl_cmd = [self.env['CURL_PATH'],

--- a/IrcamForum/IrcamFindAndDownload.py
+++ b/IrcamForum/IrcamFindAndDownload.py
@@ -16,14 +16,16 @@
 """See docstring for IrcamFindAndDownload class"""
 
 from __future__ import absolute_import
+
 import os.path
 import re
 import subprocess
-import time
-import xattr
 import tempfile
+import time
 
+import xattr
 from autopkglib import Processor, ProcessorError
+
 try:
     from autopkglib import BUNDLE_ID
 except ImportError:


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.