### PR TITLE
Add Reaper64 Notarized recipes

### DIFF
--- a/Reaper/Reaper64Notarized.download.recipe
+++ b/Reaper/Reaper64Notarized.download.recipe
@@ -15,7 +15,7 @@
 		<key>NAME</key>
 		<string>Reaper64</string>
 		<key>RE_PATTERN</key>
-		<string>(?P&lt;url&gt;files\/6\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64_catalina\.dmg)</string>
+		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64_catalina\.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Reaper/Reaper64Notarized.download.recipe
+++ b/Reaper/Reaper64Notarized.download.recipe
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Reaper64 (including ReaMote64).</string>
+	<key>Identifier</key>
+	<string>com.github.orbsmiv.download.Reaper64Notarized</string>
+	<key>Input</key>
+	<dict>
+		<key>DOWNLOAD_URL</key>
+		<string>https://www.reaper.fm/download.php</string>
+		<key>NAME</key>
+		<string>Reaper64</string>
+		<key>RE_PATTERN</key>
+		<string>(?P&lt;url&gt;files\/6\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64_catalina\.dmg)</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>re_pattern</key>
+				<string>%RE_PATTERN%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>https://www.reaper.fm/%url%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Comment</key>
+			<string>The download is verified using the REAPER64 signatures and it is assumed that this also verifies ReaMote64.</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/REAPER64.app</string>
+				<key>requirement</key>
+				<string>identifier "com.cockos.reaper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y3T58622SG</string>
+				<key>strict_verification</key>
+				<false/>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/REAPER64.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Reaper/Reaper64Notarized.munki.recipe
+++ b/Reaper/Reaper64Notarized.munki.recipe
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.3 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest versions of Reaper64 and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.orbsmiv.munki.Reaper64Notarized</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_CATEGORY</key>
+		<string>Audio</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>Reaper64</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>description</key>
+			<string>REAPER is a complete digital audio production application, offering a full multitrack audio and MIDI recording, editing, processing, mixing and mastering toolset.</string>
+			<key>developer</key>
+			<string>Cockos Incorporated</string>
+			<key>display_name</key>
+			<string>Reaper64</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.orbsmiv.download.Reaper64</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>munkiimport_appname</key>
+				<string>REAPER64.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Reaper/Reaper64Notarized.munki.recipe
+++ b/Reaper/Reaper64Notarized.munki.recipe
@@ -39,7 +39,7 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.orbsmiv.download.Reaper64</string>
+	<string>com.github.orbsmiv.download.Reaper64Notarized</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Resubmit of #11.  Along the lines of #9 & #10, this PR adds dedicated recipes for the notarized Reaper64 app version, since the download URL is different