### PR TITLE
Remove regex from input section

### DIFF
--- a/Reaper/Reaper.download.recipe
+++ b/Reaper/Reaper.download.recipe
@@ -15,7 +15,7 @@
 		<key>NAME</key>
 		<string>Reaper</string>
 		<key>RE_PATTERN</key>
-		<string>(?P&lt;url&gt;files\/5\.x\/reaper(?P&lt;version&gt;\d+\.*)_i386\.dmg)</string>
+		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_i386\.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>

--- a/Reaper/Reaper.download.recipe
+++ b/Reaper/Reaper.download.recipe
@@ -14,8 +14,6 @@
 		<string>https://www.reaper.fm/download.php</string>
 		<key>NAME</key>
 		<string>Reaper</string>
-		<key>RE_PATTERN</key>
-		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_i386\.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -27,7 +25,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>%RE_PATTERN%</string>
+				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_i386\.dmg)</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Reaper/Reaper64.download.recipe
+++ b/Reaper/Reaper64.download.recipe
@@ -14,8 +14,6 @@
 		<string>https://www.reaper.fm/download.php</string>
 		<key>NAME</key>
 		<string>Reaper64</string>
-		<key>RE_PATTERN</key>
-		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64\.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -27,7 +25,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>%RE_PATTERN%</string>
+				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64\.dmg)</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Reaper/Reaper64.download.recipe
+++ b/Reaper/Reaper64.download.recipe
@@ -15,7 +15,7 @@
 		<key>NAME</key>
 		<string>Reaper64</string>
 		<key>RE_PATTERN</key>
-		<string>(?P&lt;url&gt;files\/5\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64\.dmg)</string>
+		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64\.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
Having the regex string in the _Input_ section was causing local overrides to fail as they contained the previous (incorrect) regex.