### PR TITLE
Update Reaper64.download.recipe

### DIFF
--- a/Reaper/Reaper.download.recipe
+++ b/Reaper/Reaper.download.recipe
@@ -25,7 +25,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_i386\.dmg)</string>
+				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\w?)_i386\.dmg)</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Reaper/Reaper64.download.recipe
+++ b/Reaper/Reaper64.download.recipe
@@ -25,7 +25,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*(|.))_x86_64\.dmg)</string>
+				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\w?)_x86_64\.dmg)</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Reaper/Reaper64.download.recipe
+++ b/Reaper/Reaper64.download.recipe
@@ -25,7 +25,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64\.dmg)</string>
+				<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*(|.))_x86_64\.dmg)</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Reaper/Reaper64Notarized.download.recipe
+++ b/Reaper/Reaper64Notarized.download.recipe
@@ -15,7 +15,7 @@
 		<key>NAME</key>
 		<string>Reaper64</string>
 		<key>RE_PATTERN</key>
-		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\.*)_x86_64_catalina\.dmg)</string>
+		<string>(?P&lt;url&gt;files\/\d\.x\/reaper(?P&lt;version&gt;\d+\w?)_x86_64_catalina\.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>


### PR DESCRIPTION
Fixed URLTextSearcher re_pattern to take account for the change of version number (they suffixed a letter). This will not break if the developer decides to remove the letter in future.

Should fix https://github.com/autopkg/orbsmiv-recipes/issues/16