### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/HandBrakeCLI/HandBrakeCLI.pkg.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.pkg.recipe
@@ -53,10 +53,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/IrcamForum/AudioSculpt.pkg.recipe
+++ b/IrcamForum/AudioSculpt.pkg.recipe
@@ -57,10 +57,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/ReaperSWS/ReaperSWS.pkg.recipe
+++ b/ReaperSWS/ReaperSWS.pkg.recipe
@@ -59,10 +59,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/SpatGRIS/SpatGRIS.pkg.recipe
+++ b/SpatGRIS/SpatGRIS.pkg.recipe
@@ -96,10 +96,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/SuperCollider/SuperCollider.pkg.recipe
+++ b/SuperCollider/SuperCollider.pkg.recipe
@@ -53,10 +53,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).