### PR TITLE
Update ReaperSWS.download.recipe

### DIFF
--- a/ReaperSWS/ReaperSWS.download.recipe
+++ b/ReaperSWS/ReaperSWS.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://www.sws-extension.org</string>
+		<string>https://www.sws-extension.org</string>
 		<key>NAME</key>
 		<string>ReaperSWS</string>
 	</dict>
@@ -25,7 +25,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>download\/featured\/sws-v(\d+(?:\.\d+)*)\.dmg</string>
+				<string>download\/featured\/sws-(\d+(?:\.\d+)*)-Darwin-x86_64\.dmg</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 			</dict>


### PR DESCRIPTION
Updated to grab the 64 bit intel version of this - the recipe fails otherwise.

As the vendor now offers 32 and 64 bit intel versions as well as an arm64 Silicon version, it may be good to have separate recipes for each arch. I'd be happy to create some and host them in our dataJAR-recipes repo - please let me know if you'd prefer that.

Thank you!