### PR TITLE
Fix ReaperSWS recipes and add ARCH input variable

### DIFF
--- a/ReaperSWS/ReaperSWS.download.recipe
+++ b/ReaperSWS/ReaperSWS.download.recipe
@@ -5,7 +5,12 @@
 	<key>Comment</key>
 	<string>Created by James Carpenter</string>
 	<key>Description</key>
-	<string>Downloads the latest version of the Reaper SWS plugins</string>
+	<string>Downloads the latest version of the Reaper SWS plugins
+	
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.orbsmiv.download.ReaperSWS</string>
 	<key>Input</key>
@@ -14,6 +19,8 @@
 		<string>https://www.sws-extension.org</string>
 		<key>NAME</key>
 		<string>ReaperSWS</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -25,7 +32,7 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
-				<string>download\/featured\/sws-(\d+(?:\.\d+)*)-Darwin-x86_64\.dmg</string>
+				<string>download\/featured\/sws-(\d+(?:\.\d+)*)-Darwin-%ARCH%\.dmg</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 			</dict>
@@ -38,7 +45,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://www.sws-extension.org/download/featured/sws-v%version%.dmg</string>
+				<string>https://www.sws-extension.org/download/featured/sws-%version%-Darwin-%ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the download file pattern used to download Reaper SWS. It also adds an ARCH input variable that can be used to specify whether to download the Intel or Apple Silicon version.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'ReaperSWS/ReaperSWS.download.recipe'
Processing ReaperSWS/ReaperSWS.download.recipe...
WARNING: ReaperSWS/ReaperSWS.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'download\\/featured\\/sws-(\\d+(?:\\.\\d+)*)-Darwin-x86_64\\.dmg',
           'result_output_var_name': 'version',
           'url': 'https://www.sws-extension.org'}}
URLTextSearcher: Found matching text (version): 2.14.0.3
{'Output': {'version': '2.14.0.3'}}
URLDownloader
{'Input': {'filename': 'ReaperSWS.dmg',
           'url': 'https://www.sws-extension.org/download/featured/sws-2.14.0.3-Darwin-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 14 Sep 2024 21:29:57 GMT
URLDownloader: Storing new ETag header: "22cc39-6221b0a9680dd"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg
{'Output': {'download_changed': True,
            'etag': '"22cc39-6221b0a9680dd"',
            'last_modified': 'Sat, 14 Sep 2024 21:29:57 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/receipts/ReaperSWS.download-receipt-20241227-141625.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'ReaperSWS/ReaperSWS.download.recipe' -k ARCH=arm64
Processing ReaperSWS/ReaperSWS.download.recipe...
WARNING: ReaperSWS/ReaperSWS.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'download\\/featured\\/sws-(\\d+(?:\\.\\d+)*)-Darwin-arm64\\.dmg',
           'result_output_var_name': 'version',
           'url': 'https://www.sws-extension.org'}}
URLTextSearcher: Found matching text (version): 2.14.0.3
{'Output': {'version': '2.14.0.3'}}
URLDownloader
{'Input': {'filename': 'ReaperSWS.dmg',
           'url': 'https://www.sws-extension.org/download/featured/sws-2.14.0.3-Darwin-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 14 Sep 2024 21:29:56 GMT
URLDownloader: Storing new ETag header: "1dbc7c-6221b0a8cbcbb"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg
{'Output': {'download_changed': True,
            'etag': '"1dbc7c-6221b0a8cbcbb"',
            'last_modified': 'Sat, 14 Sep 2024 21:29:56 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/receipts/ReaperSWS.download-receipt-20241227-141632.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.ReaperSWS/downloads/ReaperSWS.dmg
```
