### PR TITLE
Deprecate Reaper64Notarized recipes

### DIFF
--- a/Reaper/Reaper64Notarized.download.recipe
+++ b/Reaper/Reaper64Notarized.download.recipe
@@ -22,6 +22,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>REAPER64 has become REAPER again, please use the following recipe: https://github.com/autopkg/orbsmiv-recipes/blob/master/Reaper/Reaper.download.recipe.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>


### PR DESCRIPTION
This PR copies the deprecation warning from the Reaper64 recipes to the Reaper64Notarized recipes.
