### PR TITLE
Fix LilyPond recipes

### DIFF
--- a/LilyPond/LilyPond.download.recipe
+++ b/LilyPond/LilyPond.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://lilypond.org/macos-x.html</string>
+		<string>https://lilypond.org/download.html</string>
 		<key>NAME</key>
 		<string>LilyPond</string>
 	</dict>
@@ -24,7 +24,8 @@
 				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
 				<!-- <string>http://download.linuxaudio.org/lilypond/binaries/darwin-x86/.*?\.bz2</string> -->
-				<string>(http://lilypond.org/download/binaries/darwin-x86/.*?(?P&lt;version&gt;\d+\.\d+\.\d+).*?\.bz2)</string>
+				<!-- <string>(http://lilypond.org/download/binaries/darwin-x86/.*?(?P&lt;version&gt;\d+\.\d+\.\d+).*?\.bz2)</string> -->
+				<string>href="(https://gitlab.com/lilypond/lilypond/-/releases/v(?P&lt;version&gt;[\d\.]+)/downloads/lilypond-[\d\.]+-darwin-x86_64.tar.gz)"</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -33,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.tar.bz2</string>
+				<string>%NAME%-%version%.tar.gz</string>
 				<key>url</key>
 				<string>%match%</string>
 			</dict>


### PR DESCRIPTION
This PR updates the download page and file pattern matching used to download LilyPond.

Verbose recipe run output:

```
% autopkg run -vvq 'LilyPond/LilyPond.download.recipe'
Processing LilyPond/LilyPond.download.recipe...
WARNING: LilyPond/LilyPond.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://gitlab.com/lilypond/lilypond/-/releases/v(?P<version>[\\d\\.]+)/downloads/lilypond-[\\d\\.]+-darwin-x86_64.tar.gz)"',
           'url': 'https://lilypond.org/download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (version): 2.24.4
URLTextSearcher: Found matching text (match): https://gitlab.com/lilypond/lilypond/-/releases/v2.24.4/downloads/lilypond-2.24.4-darwin-x86_64.tar.gz
{'Output': {'match': 'https://gitlab.com/lilypond/lilypond/-/releases/v2.24.4/downloads/lilypond-2.24.4-darwin-x86_64.tar.gz',
            'version': '2.24.4'}}
URLDownloader
{'Input': {'filename': 'LilyPond-2.24.4.tar.gz',
           'url': 'https://gitlab.com/lilypond/lilypond/-/releases/v2.24.4/downloads/lilypond-2.24.4-darwin-x86_64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 20 Jul 2024 13:28:16 GMT
URLDownloader: Storing new ETag header: "f206d7051fa985b7ec4e4557fa7d5dbc"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.LilyPond/downloads/LilyPond-2.24.4.tar.gz
{'Output': {'download_changed': True,
            'etag': '"f206d7051fa985b7ec4e4557fa7d5dbc"',
            'last_modified': 'Sat, 20 Jul 2024 13:28:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.orbsmiv.download.LilyPond/downloads/LilyPond-2.24.4.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.orbsmiv.download.LilyPond/downloads/LilyPond-2.24.4.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.LilyPond/receipts/LilyPond.download-receipt-20241227-140555.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.orbsmiv.download.LilyPond/downloads/LilyPond-2.24.4.tar.gz
```
