### PR TITLE
Deprecate AudioSculpt recipes

### DIFF
--- a/IrcamForum/AudioSculpt.download.recipe
+++ b/IrcamForum/AudioSculpt.download.recipe
@@ -22,6 +22,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>AudioSculpt is no longer under active development or support (details: https://forum.ircam.fr/projects/detail/audiosculpt/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the AudioSculpt recipes, as the software is no longer developed or supported ([details](https://forum.ircam.fr/projects/detail/audiosculpt/)).
