### PR TITLE
HandBrakeCLI fixes

### DIFF
--- a/HandBrakeCLI/HandBrakeCLI.download.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest HandbrakeCLI disk image.
+    <string>Downloads the latest HandBrakeCLI disk image.
 Set PRERELEASE to a non-empty string to download prereleases, either
 via Input in an override or via the -k option,
 i.e.: `-k PRERELEASE=yes`</string>
@@ -12,7 +12,7 @@ i.e.: `-k PRERELEASE=yes`</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>HandbrakeCLI</string>
+        <string>HandBrakeCLI</string>
         <key>PRERELEASE</key>
         <string></string>
     </dict>

--- a/HandBrakeCLI/HandBrakeCLI.download.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.download.recipe
@@ -3,38 +3,36 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest Handbrake CLI disk image.</string>
+    <string>Downloads the latest HandbrakeCLI disk image.
+Set PRERELEASE to a non-empty string to download prereleases, either
+via Input in an override or via the -k option,
+i.e.: `-k PRERELEASE=yes`</string>
     <key>Identifier</key>
     <string>com.github.orbsmiv.download.HandBrakeCLI</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>HandBrakeCLI</string>
+        <string>HandbrakeCLI</string>
+        <key>PRERELEASE</key>
+        <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.9</string>
+    <string>1.0.4</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://handbrake.fr/downloads2.php</string>
-                <key>re_pattern</key>
-                <string>(rotation.*?CLI-(?P&lt;version&gt;\d\.\d\.\d)\.dmg)</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://handbrake.fr/%match%</string>
-                <key>re_pattern</key>
-                <string>href=\"(https.*?HandBrake.*?\.dmg)\"</string>
+                <key>github_repo</key>
+                <string>HandBrake/HandBrake</string>
+                <key>include_prereleases</key>
+                <string>%PRERELEASE%</string>
+                <key>sort_by_highest_tag_names</key>
+                <string>True</string>
+                <key>asset_regex</key>
+                <string>HandBrakeCLI-\S.*?.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -44,15 +42,24 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>url</key>
-                <string>%match%</string>
-                <key>CHECK_FILESIZE_ONLY</key>
-                <true/>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/HandBrakeCLI</string>
+                <key>requirement</key>
+                <string>identifier "fr.handbrake.HandBrakeCLI" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5X9DE89KYV"</string>
+                <key>strict_verification</key>
+                <true />
+            </dict>
         </dict>
     </array>
 </dict>

--- a/HandBrakeCLI/HandBrakeCLI.munki.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Handbrake CLI disk image and imports it into Munki.</string>
+	<string>Downloads the latest HandBrake CLI disk image and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.orbsmiv.munki.HandBrakeCLI</string>
 	<key>Input</key>
@@ -21,7 +21,7 @@
 			<key>description</key>
 			<string>HandBrakeCLI is the command-line version of the popular HandBrake tool for converting video from nearly any format to a selection of modern, widely supported codecs.</string>
 			<key>display_name</key>
-			<string>HandbrakeCLI</string>
+			<string>HandBrakeCLI</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>

--- a/HandBrakeCLI/HandBrakeCLI.munki.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of the Sennheiser Ambeo plugin and imports it into Munki.</string>
+	<string>Downloads the latest Handbrake CLI disk image and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.orbsmiv.munki.HandBrakeCLI</string>
 	<key>Input</key>

--- a/HandBrakeCLI/HandBrakeCLI.pkg.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of the Sennheiser Ambeo plugin and imports it into Munki.</string>
+	<string>Downloads the latest Handbrake CLI disk image and builds a pkg.</string>
 	<key>Identifier</key>
 	<string>com.github.orbsmiv.pkg.HandBrakeCLI</string>
 	<key>Input</key>

--- a/HandBrakeCLI/HandBrakeCLI.pkg.recipe
+++ b/HandBrakeCLI/HandBrakeCLI.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Handbrake CLI disk image and builds a pkg.</string>
+	<string>Downloads the latest HandBrake CLI disk image and builds a pkg.</string>
 	<key>Identifier</key>
 	<string>com.github.orbsmiv.pkg.HandBrakeCLI</string>
 	<key>Input</key>


### PR DESCRIPTION
The HandBrakeCLI recipe stopped working for me a few days ago. I noticed that [the main HandBrake recipe](https://github.com/autopkg/recipes/tree/master/Handbrake) used `GitHubReleasesInfoProvider` instead of trying to parse HandBrake's website, and the CLI tool is also posted to the same location - so I almost completely copied the other recipe and overwrote the existing `download` recipe. I tested both the `munki` and `pkg` recipes and they still work great, though I fixed their descriptions so they show correctly on [AutoPkgWeb](https://autopkgweb.com).